### PR TITLE
Add zero2robot to Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ University courses and structured learning programs in robot learning and embodi
 - [MIT Underactuated Robotics](https://underactuated.mit.edu/) — Open textbook/course on dynamics, planning, and control for underactuated systems.
 - [Fast.ai Practical Deep Learning](https://course.fast.ai/) — Applied deep-learning curriculum useful for perception and representation foundations.
 - [CS 234 — Reinforcement Learning (Stanford)](https://web.stanford.edu/class/cs234/) — Core RL theory and algorithms with strong academic grounding.
-- [zero2robot](https://www.zero2robot.com/) — Free, from-scratch course: build an embodied-AI robot brain one readable file at a time, from a bare MuJoCo loop to a vision-language-action policy, on a free Colab T4 or CPU laptop.
+- [zero2robot](https://www.zero2robot.com) — Free, from-scratch course on embodied AI that builds MuJoCo-based agents from a basic simulation loop to training a vision-language-action policy.
 
 ## Companies
 

--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ University courses and structured learning programs in robot learning and embodi
 - [MIT Underactuated Robotics](https://underactuated.mit.edu/) — Open textbook/course on dynamics, planning, and control for underactuated systems.
 - [Fast.ai Practical Deep Learning](https://course.fast.ai/) — Applied deep-learning curriculum useful for perception and representation foundations.
 - [CS 234 — Reinforcement Learning (Stanford)](https://web.stanford.edu/class/cs234/) — Core RL theory and algorithms with strong academic grounding.
+- [zero2robot](https://www.zero2robot.com/) — Free, from-scratch course: build an embodied-AI robot brain one readable file at a time, from a bare MuJoCo loop to a vision-language-action policy, on a free Colab T4 or CPU laptop.
 
 ## Companies
 


### PR DESCRIPTION
Adds **zero2robot** (https://www.zero2robot.com/) to the Courses section.

It's a free, from-scratch course on embodied AI: you build a robot brain one readable file per chapter, from a bare MuJoCo simulation loop up to a vision-language-action policy you train, evaluate, export, and drive in the browser. Everything runs on a free Colab T4 or a CPU laptop (no robot or GPU required), which fits this list's learn/build/deploy framing and sits alongside the other non-institutional entries (Spinning Up, the HF Deep RL Course, fast.ai).

- Site: https://www.zero2robot.com/
- Browser playground (MuJoCo compiled to WASM): https://play.zero2robot.com/
- Source: https://github.com/kaushikb11/zero2robot

Disclosure: I'm the author of this resource. Happy to adjust the wording or move it to Tutorials & Guides if you'd prefer.