### PR TITLE
Add ActionShift — hidden action-interface adaptation benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Task suites and standardised evaluations for manipulation, locomotion, and embod
 
 - [LIBERO](https://libero-project.github.io/) — Lifelong robot learning benchmark with 130 diverse manipulation tasks.
 - [RLBench](https://sites.google.com/view/rlbench) — Vision-guided manipulation benchmark covering 100+ tasks in CoppeliaSim.
+- [ActionShift](https://github.com/Archerkattri/actionshift) — ManiSkill benchmark that hides the action-interface contract (channel permutation, sign, scale, delta/absolute, frame, lag, gripper) from a frozen competent policy, with preregistered splits, a privileged oracle, and promotion gates for adaptation methods.
 - [MetaWorld](https://meta-world.github.io/) — Meta-RL benchmark with 50 manipulation tasks for multi-task and transfer studies.
 - [CALVIN](https://github.com/mees/calvin) — Benchmark for long-horizon, language-conditioned manipulation.
 - [HumanoidBench](https://humanoid-bench.github.io/) — Simulated humanoid benchmark for whole-body control across locomotion and manipulation.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ Task suites and standardised evaluations for manipulation, locomotion, and embod
 
 - [LIBERO](https://libero-project.github.io/) — Lifelong robot learning benchmark with 130 diverse manipulation tasks.
 - [RLBench](https://sites.google.com/view/rlbench) — Vision-guided manipulation benchmark covering 100+ tasks in CoppeliaSim.
-- [ActionShift](https://github.com/Archerkattri/actionshift) — ManiSkill benchmark that hides the action-interface contract (channel permutation, sign, scale, delta/absolute, frame, lag, gripper) from a frozen competent policy, with preregistered splits, a privileged oracle, and promotion gates for adaptation methods.
 - [MetaWorld](https://meta-world.github.io/) — Meta-RL benchmark with 50 manipulation tasks for multi-task and transfer studies.
 - [CALVIN](https://github.com/mees/calvin) — Benchmark for long-horizon, language-conditioned manipulation.
 - [HumanoidBench](https://humanoid-bench.github.io/) — Simulated humanoid benchmark for whole-body control across locomotion and manipulation.
@@ -180,6 +179,7 @@ Task suites and standardised evaluations for manipulation, locomotion, and embod
 - [TEACh](https://teach.cs.washington.edu/) — Interactive benchmark for embodied dialog and task execution in household environments.
 - [RoboTHOR](https://ai2thor.allenai.org/robothor/) — Navigation benchmark focused on sim-to-real transfer and unseen-scene generalization.
 - [ManiSkill Benchmark](https://github.com/haosulab/ManiSkill) — Manipulation benchmark suite with scalable GPU simulation and reproducible baselines.
+- [ActionShift](https://github.com/Archerkattri/actionshift) — ManiSkill benchmark that hides the action-interface contract (permutation, sign, scale, delta/absolute, frame, lag, gripper) from a frozen competent policy, with preregistered splits, a privileged oracle, and promotion gates.
 
 ## Evaluation Methodology
 

--- a/website/docs/categories/benchmarks.mdx
+++ b/website/docs/categories/benchmarks.mdx
@@ -31,3 +31,4 @@ When choosing a benchmark, match the **task family** (manipulation, locomotion, 
 - [TEACh](https://teach.cs.washington.edu/) — Interactive benchmark for embodied dialog and task execution in household environments.
 - [RoboTHOR](https://ai2thor.allenai.org/robothor/) — Navigation benchmark focused on sim-to-real transfer and unseen-scene generalization.
 - [ManiSkill Benchmark](https://github.com/haosulab/ManiSkill) — Manipulation benchmark suite with scalable GPU simulation and reproducible baselines.
+- [ActionShift](https://github.com/Archerkattri/actionshift) — ManiSkill benchmark that hides the action-interface contract (permutation, sign, scale, delta/absolute, frame, lag, gripper) from a frozen competent policy, with preregistered splits, a privileged oracle, and promotion gates.


### PR DESCRIPTION
Adds [ActionShift](https://github.com/Archerkattri/actionshift) to the Benchmarks section: a ManiSkill-3-based benchmark where a frozen, competent policy must adapt to a hidden compositional action-interface contract (permutation/sign/scale/delta-vs-absolute/frame/lag/gripper) — dynamics stay fixed, only the software contract is hidden. Preregistered seen/unseen-composition/long-lag splits, privileged oracle, promotion gates, MIT license, CI green, archived at doi:10.5281/zenodo.21500713.