### PR TITLE
Add Physical AI Atlas to Related Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ Other curated lists covering adjacent topics.
 - [Awesome Deep RL](https://github.com/kengz/awesome-deep-rl) - Deep reinforcement learning resources.
 - [Awesome Imitation Learning](https://github.com/kristery/Awesome-Imitation-Learning) - Learning from demonstrations.
 - [Bipedal Robot Learning Collection](https://github.com/zita-ch/bipedal-robot-learning-collection) - Curated bipedal/humanoid robot-learning papers with a sim-to-real focus.
+- [Physical AI Atlas](https://github.com/PlbKin190/physical-ai-atlas-data) - Bilingual FR/EN ecosystem index published as machine-readable JSON, covering humanoid robots, industrial platforms, VLA models, embedded chips, simulators and labs.
 
 ---
 


### PR DESCRIPTION
Adds one entry to the **Related Awesome Lists** appendix.

```markdown
- [Physical AI Atlas](https://github.com/PlbKin190/physical-ai-atlas-data) - Bilingual FR/EN ecosystem index published as machine-readable JSON, covering humanoid robots, industrial platforms, VLA models, embedded chips, simulators and labs.
```

### Why this section and not Datasets

The Datasets category is described as "large-scale teleoperation, demonstration, and interaction datasets used to train robot policies" — Open X-Embodiment, DROID, BridgeData. The Atlas is not a training corpus and would be a category error there. It indexes the *entities* of the ecosystem — hardware, chips, simulators, labs, companies — which is what the Related Awesome Lists appendix already collects, so that is where I put it.

### Why it adds something

The adjacent lists in that appendix are paper and link collections. This one is published as machine-readable JSON against a documented schema, so it can be queried rather than only read. Every entity carries its own `last_verified` date and source list, and EMEA presence is a first-class field where most sector overviews are US- and China-centric. 13 datasets, bilingual FR/EN.

### Being upfront about the quality gates

CONTRIBUTING sets ">100 stars, ideally" for software and tools. The data repository was published on 2026-07-28 and has no stars yet, so that gate is honestly unmet. I am submitting anyway because the entry is a related-list pointer rather than a tool recommendation, and because the uniqueness argument stands on its own — but a "come back when it has traction" is a fair call and I will not argue with it.

Formatting follows the local section style: `- ` separator with a hyphen (not the em dash used in the canonical categories), one sentence, terminal period, no trailing slash, added at the bottom of the section. No tags, since no entry in that appendix carries them. No `website/docs/categories/` mirror exists for the appendices, so the README is the only file that changes.

Disclosure: I maintain the Atlas.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Physical AI Atlas to the related awesome lists section in README
> Adds a bullet for [Physical AI Atlas](https://github.com/PlbKin190/physical-ai-atlas-data) to the curated lists section of [README.md](https://github.com/natnew/awesome-physical-ai/pull/16/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f35ba9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->