### PR TITLE
fix(ci): keep one curation review open at a time

### DIFF
--- a/.github/workflows/curation-review.yml
+++ b/.github/workflows/curation-review.yml
@@ -26,16 +26,58 @@ jobs:
         with:
           script: |
             const monthTag = process.env.MONTH_TAG;
-            const title = `Curation review — ${monthTag}`;
+            const titlePrefix = 'Curation review — ';
+            const title = `${titlePrefix}${monthTag}`;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            // Idempotency: skip if an open issue with the same title already exists.
-            const q = `repo:${owner}/${repo} is:issue is:open in:title "${title}"`;
-            const existing = await github.rest.search.issuesAndPullRequests({ q, per_page: 5 });
-            const match = existing.data.items.find(i => i.title === title);
-            if (match) {
-              core.info(`Open issue already exists: #${match.number} ${match.html_url}`);
+            // Keep exactly one curation review open at a time.
+            //
+            // A review still open when the next cycle comes round is the review that
+            // needs finishing; opening a second issue over it grows the queue without
+            // adding information. So: skip creation, and leave a dated note on the
+            // open review instead.
+            //
+            // Listed rather than searched: the search index is eventually consistent
+            // and can miss a recently created issue, which would defeat the guard.
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: 'curation',
+              per_page: 100,
+            });
+            const reviews = openIssues
+              .filter(i => !i.pull_request && i.title.startsWith(titlePrefix))
+              .sort((a, b) => a.number - b.number);
+
+            const currentMonth = reviews.find(i => i.title === title);
+            if (currentMonth) {
+              core.info(`Review for ${monthTag} already open: #${currentMonth.number}`);
+              return;
+            }
+
+            const openReview = reviews[0];
+            if (openReview) {
+              // One note per cycle, so manual workflow_dispatch re-runs stay quiet.
+              const marker = `<!-- curation-review-cycle:${monthTag} -->`;
+              const priorComments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: openReview.number,
+                per_page: 100,
+              });
+              if (priorComments.some(c => (c.body || '').includes(marker))) {
+                core.info(`Cycle ${monthTag} already noted on #${openReview.number}.`);
+                return;
+              }
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: openReview.number,
+                body: `${marker}\nThe ${monthTag} cycle opened while this review is still in progress. No new issue created — this remains the active review.`,
+              });
+              core.info(`Noted cycle ${monthTag} on #${openReview.number}; skipped creation.`);
               return;
             }
 

--- a/website/docs/workflow-review.mdx
+++ b/website/docs/workflow-review.mdx
@@ -55,6 +55,6 @@ When removing a stale entry, add a one-line comment in the PR description noting
 
 ## Recommended cadence
 
-**Monthly.** A scheduled GitHub Action (`.github/workflows/curation-review.yml`) opens a `Curation review — YYYY-MM` issue on the first of each month at 09:00 UTC, and can also be triggered manually via `workflow_dispatch` from the Actions tab. The workflow is idempotent — re-running it within the same month will not create a duplicate issue.
+**Monthly.** A scheduled GitHub Action (`.github/workflows/curation-review.yml`) opens a `Curation review — YYYY-MM` issue on the first of each month at 09:00 UTC, and can also be triggered manually via `workflow_dispatch` from the Actions tab. The workflow keeps exactly one review open at a time. Re-running it within the same month will not create a duplicate, and if a previous month's review is still open when a new cycle begins, the workflow leaves a dated note on that review rather than opening a second issue — so the open queue always reflects the review actually outstanding.
 
 Any maintainer can open an ad-hoc review issue at any time if a specific problem is noticed — a dead-link surge, a major new entrant in a category, or relevance drift after a significant field development.


### PR DESCRIPTION
## Summary

The scheduled curation review job only checked whether the *current month's* issue was already open, so an unfinished review never suppressed the next cycle. Four identical review issues accumulated between 2026-05 and 2026-08 (#6, #7, #9, #15). This widens the guard to any open review, and syncs the docs page that describes the behaviour.

## Change type

- [ ] Add resource
- [ ] Remove resource
- [ ] New category (≥3 seed entries)
- [x] Fix (broken link, typo, miscategorisation)
- [x] Docs / site

## What changed

`.github/workflows/curation-review.yml`

- The guard now matches **any** open issue carrying the `curation` label whose title starts with `Curation review — `, not just the current month's exact title.
- When a previous month's review is still open, the workflow leaves a dated note on it and skips creation, so the queue reflects the review actually outstanding.
- The note carries a hidden per-cycle marker (`<!-- curation-review-cycle:YYYY-MM -->`) so manual `workflow_dispatch` re-runs stay quiet.
- Issues are now listed by label rather than fetched via the search API, whose index is eventually consistent and can miss a recently created issue — which would defeat the guard.

`website/docs/workflow-review.mdx`

- The cadence paragraph described the old narrower behaviour. Updated to match.

No change to the `schedule:` trigger or to `permissions:` (`issues: write` already covers commenting).

## Verification

Replacing the template's "Why this is awesome" section, which applies to resource submissions rather than an infrastructure fix.

| Check | Result |
|---|---|
| YAML parses; extracted script passes `node --check`; em dash survives as U+2014 | Pass |
| Logic harness, 7 scenarios against a stubbed API | Pass |
| Read-only replay against live repository data | Pass — zero writes |
| `npm run lint:docs` / `npm run build` | Pass |

The seven harness scenarios: no open review creates one; current-month open is a silent skip; stale open with no marker leaves exactly one note and creates nothing; stale open with the marker is fully silent; a PR carrying a review-shaped title is ignored; an unrelated `curation` issue does not suppress creation; with two stale reviews open only the oldest is annotated.

The replay confirms that against today's data the guard identifies #15 and performs no writes at all.

## Reviewer notes

- The stale-review path cannot be exercised end-to-end before merge without closing #15 and reopening a prior month, which would mean mutating public issue state to satisfy a test. It is covered by the harness and the replay, and fires naturally on **1 September**: expect no `Curation review — 2026-09` issue, and exactly one dated note added to #15.
- Category placement, entry formatting and link checklist items are not applicable — no README entries are touched.

## Checklist

- [x] Followed CONTRIBUTING.md where applicable
- [x] Docs page kept in sync with the behaviour change
- [x] No README entries added, removed, or reordered
- [x] No protected areas touched beyond the workflow this fix targets
