### PR TITLE
chore: restore entry-count baseline and add a self-verifying status line

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Built for researchers and practitioners across the stack — from foundations to
   </a>
 </p>
 
+<p align="center">
+  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>225 entries</strong> across 14 canonical categories</sub>
+</p>
+
 <div align="center">
 
 <details>
@@ -292,7 +296,6 @@ Legged, bipedal, and humanoid locomotion — controllers, learning approaches, a
 - [HumanPlus](https://humanoid-ai.github.io/) — Humanoid shadowing of human motion for whole-body control via teleoperation and RL.
 - [OmniH2O](https://omni.human2humanoid.com/) — Universal whole-body teleoperation and learning for humanoids.
 - [RSL-RL](https://github.com/leggedrobotics/rsl_rl) — Fast PPO implementation from ETH Zurich tuned for legged-robot RL on GPU simulators.
-- [legged_gym](https://github.com/leggedrobotics/legged_gym) — Reference Isaac Gym/Isaac Lab environments for legged locomotion research.
 - [DeepMimic](https://xbpeng.github.io/projects/DeepMimic/index.html) — Physics-based character control from motion imitation, foundational for agile RL locomotion.
 - [Walk These Ways](https://gmargo11.github.io/walk-these-ways/) — Learning framework for robust quadruped locomotion over varied terrain and command regimes.
 - [Rapid Locomotion via RL](https://arxiv.org/abs/2207.07802) — Sim-to-real locomotion approach focused on high-speed deployment-ready policies.

--- a/scripts/check_entry_counts.py
+++ b/scripts/check_entry_counts.py
@@ -6,14 +6,30 @@ is within the 15–25 entry target band.
 Usage:
     python scripts/check_entry_counts.py
 
+It also verifies that the "Last updated / N entries" status line in
+README.md reports the true total, so the hand-maintained figure cannot
+drift away from the list it describes.
+
 Exit codes:
-    0 — all categories within [15, 25]
-    1 — one or more categories outside the band
+    0 — all categories within [15, 25] and the status-line total is correct
+    1 — a category is outside the band, or the status line is missing/stale
 """
 
 import re
 import sys
 from pathlib import Path
+
+# Matches the centred status line near the top of README.md.
+STATUS_LINE_RE = re.compile(
+    r"<strong>Last updated:</strong>\s*(\d{4}-\d{2}-\d{2})"
+    r".*?<strong>(\d+) entries</strong>"
+)
+
+# The ⚠ glyph is not representable in the cp1252 console Windows uses by
+# default, and printing it there raises UnicodeEncodeError. Force UTF-8 so
+# the script reports a verdict instead of a traceback.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 TARGET_LOW = 15
 TARGET_HIGH = 25
@@ -111,9 +127,26 @@ def main() -> int:
             status = "OK"
         print(f"{category:<{col_w}} {count:>5}  {status}")
 
+    total = sum(counts.values())
+    print(f"{'TOTAL':<{col_w}} {total:>5}")
+
+    status = STATUS_LINE_RE.search(readme.read_text(encoding="utf-8"))
+    print()
+    if status is None:
+        print("FAIL — no 'Last updated / N entries' status line found in README.md.")
+        any_fail = True
+    elif int(status.group(2)) != total:
+        print(
+            f"FAIL — README status line claims {status.group(2)} entries, "
+            f"but the categories hold {total}."
+        )
+        any_fail = True
+    else:
+        print(f"Status line OK — {total} entries, last updated {status.group(1)}.")
+
     print()
     if any_fail:
-        print(f"FAIL — one or more categories outside [{TARGET_LOW}, {TARGET_HIGH}].")
+        print("FAIL — see the errors above.")
         return 1
 
     print(f"PASS — all categories within [{TARGET_LOW}, {TARGET_HIGH}].")

--- a/website/docs/categories/locomotion.mdx
+++ b/website/docs/categories/locomotion.mdx
@@ -13,7 +13,7 @@ From an engineering standpoint, locomotion is the category where sim-to-real *wo
 When choosing between approaches, weigh **platform** (quadruped vs. biped vs. humanoid), **simulator and trainer** (Isaac Lab + RSL-RL is the current default), and **perceptive vs. blind** locomotion based on the terrain you actually need. Reference platforms and open codebases matter disproportionately here: most production locomotion stacks are forks of a small number of well-maintained repositories.
 
 :::tip Start here
-**[Learning to Walk in Minutes (ETH/RSL)](https://leggedrobotics.github.io/legged_gym/)** is the canonical entry point: GPU-parallel RL with a working sim-to-real pipeline for quadrupeds. It pairs naturally with [RSL-RL](https://github.com/leggedrobotics/rsl_rl) (the PPO trainer) and [legged_gym](https://github.com/leggedrobotics/legged_gym) (the environments), both listed below.
+**[Learning to Walk in Minutes (ETH/RSL)](https://leggedrobotics.github.io/legged_gym/)** is the canonical entry point: GPU-parallel RL with a working sim-to-real pipeline for quadrupeds. It pairs naturally with [RSL-RL](https://github.com/leggedrobotics/rsl_rl) (the PPO trainer, listed below) and the [legged_gym](https://github.com/leggedrobotics/legged_gym) environments it builds on.
 :::
 
 - [Learning to Walk in Minutes (ETH/RSL)](https://leggedrobotics.github.io/legged_gym/) — Massively-parallel RL pipeline that trains quadruped locomotion policies from scratch in simulation.
@@ -23,7 +23,6 @@ When choosing between approaches, weigh **platform** (quadruped vs. biped vs. hu
 - [HumanPlus](https://humanoid-ai.github.io/) — Humanoid shadowing of human motion for whole-body control via teleoperation and RL.
 - [OmniH2O](https://omni.human2humanoid.com/) — Universal whole-body teleoperation and learning for humanoids.
 - [RSL-RL](https://github.com/leggedrobotics/rsl_rl) — Fast PPO implementation from ETH Zurich tuned for legged-robot RL on GPU simulators.
-- [legged_gym](https://github.com/leggedrobotics/legged_gym) — Reference Isaac Gym/Isaac Lab environments for legged locomotion research.
 - [DeepMimic](https://xbpeng.github.io/projects/DeepMimic/index.html) — Physics-based character control from motion imitation, foundational for agile RL locomotion.
 - [Walk These Ways](https://gmargo11.github.io/walk-these-ways/) — Learning framework for robust quadruped locomotion over varied terrain and command regimes.
 - [Rapid Locomotion via RL](https://arxiv.org/abs/2207.07802) — Sim-to-real locomotion approach focused on high-speed deployment-ready policies.


### PR DESCRIPTION
## What

Three related maintenance changes that put `check_entry_counts.py` back to green and keep it that way.

**1. Remove a duplicate Locomotion entry (26 → 25)**

Locomotion carried the same project twice:

| Entry | URL |
|---|---|
| Learning to Walk in Minutes (ETH/RSL) | `leggedrobotics.github.io/legged_gym/` |
| legged_gym | `github.com/leggedrobotics/legged_gym` |

One is the project page for the other. The category sat at 26, one over the 15–25 band, so the entry-count check failed on `main`.

The `legged_gym` bullet is the one removed. `Learning to Walk in Minutes` is the category's **Start here** entry, and the Start here tip already links `legged_gym` inline — so the repository stays reachable and no Start here marker moves. The tip's wording is corrected, since "both listed below" is no longer accurate.

**2. Add a maintained status line to `README.md`**

```
Last updated: 2026-08-20 · 225 entries across 14 canonical categories
```

**3. Make that line self-verifying**

`check_entry_counts.py` now parses the status line and fails if the number disagrees with the real total. A hand-maintained count drifts the moment someone forgets to update it; this turns a stale figure into a check failure rather than a quiet inaccuracy.

## Verification

```
Locomotion                          25  OK
TOTAL                              225
Status line OK — 225 entries, last updated 2026-08-20.
PASS — all categories within [15, 25].
```

`npm run lint:docs` exit 0. `npm run build` exit 0.

## Files

- `README.md`
- `website/docs/categories/locomotion.mdx` (kept in sync)
- `scripts/check_entry_counts.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
