### PR TITLE
docs: add MEM (Multi-Scale Embodied Memory) to Robotics Foundation Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Built for researchers and practitioners across the stack — from foundations to
 </p>
 
 <p align="center">
-  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>225 entries</strong> across 14 canonical categories</sub>
+  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>226 entries</strong> across 14 canonical categories</sub>
 </p>
 
 <div align="center">
@@ -238,6 +238,8 @@ Generalist policies and vision-language-action (VLA) models for robotic control.
 <!-- tags: paper -->
 - [RoboFlamingo](https://arxiv.org/abs/2311.01378) — Open vision-language-action model for low-cost adaptation to robot manipulation tasks.
 <!-- tags: paper, open-source -->
+- [MEM — Multi-Scale Embodied Memory](https://arxiv.org/abs/2603.03596) — Memory architecture for vision-language-action models pairing a video encoder for short-horizon recall with language-based long-horizon memory.
+<!-- tags: paper -->
 
 ## World Models
 

--- a/website/docs/categories/robotics-foundation-models.mdx
+++ b/website/docs/categories/robotics-foundation-models.mdx
@@ -31,3 +31,4 @@ When choosing between options, weigh **embodiment coverage** vs. your target rob
 - [VIMA](https://arxiv.org/abs/2210.03094) — Promptable transformer for multimodal robot manipulation via in-context generalization.
 - [Gato](https://arxiv.org/abs/2205.06175) — Generalist policy architecture spanning embodied control and non-robotic tasks with tokenized actions.
 - [RoboFlamingo](https://arxiv.org/abs/2311.01378) — Open vision-language-action model for low-cost adaptation to robot manipulation tasks.
+- [MEM — Multi-Scale Embodied Memory](https://arxiv.org/abs/2603.03596) — Memory architecture for vision-language-action models pairing a video encoder for short-horizon recall with language-based long-horizon memory.


### PR DESCRIPTION
## The resource

**[MEM: Multi-Scale Embodied Memory for Vision Language Action Models](https://arxiv.org/abs/2603.03596)** — Torne, Pertsch, Walke, Vedder, Nair, Ichter, Ren, Stachowicz, Springenberg, Levine, Finn, Driess et al. (Physical Intelligence). arXiv, March 2026.

A memory architecture for VLA policies. It argues that long-horizon embodied control needs memory at more than one level of abstraction, and combines two mechanisms to get there: an efficient video encoder for short-horizon, image-based recall that compensates for occlusion, and a language-based store for long-horizon semantic memory. Trained on a mix of robot and non-robot data, the resulting policies handle partial observability, adapt manipulation strategy in context, and complete tasks requiring up to roughly fifteen minutes of retained state — kitchen cleanup, sandwich preparation.

## Why it belongs on the list

- **Fills a real gap.** The list covers VLA architectures well — RT-1, RT-2, PaLM-E, OpenVLA, Octo, π0 — but every one of those is effectively memoryless at the task level. Memory is the constraint that separates single-step manipulation from multi-stage work, and nothing currently on the list addresses it.
- **Durable and canonical.** arXiv preprint from the Physical Intelligence group behind π0, which the list already carries. Author list includes Levine, Finn, and Driess.
- **Technically substantive.** A concrete architecture with an evaluation, not a launch post or a position paper.

## Placement

**Robotics Foundation Models**, appended at the bottom of the section alongside the other VLA method papers (PaLM-E, SayCan, VIMA, Gato, RoboFlamingo). It is a method for VLA models rather than a manipulation technique or a benchmark, so no other section is a closer fit and no new section is needed.

Category count: 15 → 16, inside the 15–25 band.

## Verification

```
Robotics Foundation Models          16  OK
TOTAL                              226
Status line OK — 226 entries, last updated 2026-08-20.
PASS — all categories within [15, 25].
```

## Files

- `README.md` — entry plus `<!-- tags: paper -->`, status line 225 → 226
- `website/docs/categories/robotics-foundation-models.mdx` — kept in sync

## Note on ordering

Based on `chore/entry-count-baseline` (#19), not `main`. That PR removes a duplicate Locomotion entry which currently puts the category at 26 and fails the entry-count check, and adds the status line this PR increments. Merge #19 first; the base retargets to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
