### PR TITLE
docs: add R&B-EnCoRe to Robotics Foundation Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Built for researchers and practitioners across the stack — from foundations to
 </p>
 
 <p align="center">
-  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>226 entries</strong> across 14 canonical categories</sub>
+  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>227 entries</strong> across 14 canonical categories</sub>
 </p>
 
 <div align="center">
@@ -239,6 +239,8 @@ Generalist policies and vision-language-action (VLA) models for robotic control.
 - [RoboFlamingo](https://arxiv.org/abs/2311.01378) — Open vision-language-action model for low-cost adaptation to robot manipulation tasks.
 <!-- tags: paper, open-source -->
 - [MEM — Multi-Scale Embodied Memory](https://arxiv.org/abs/2603.03596) — Memory architecture for vision-language-action models pairing a video encoder for short-horizon recall with language-based long-horizon memory.
+<!-- tags: paper -->
+- [R&B-EnCoRe](https://arxiv.org/abs/2602.08167) — Self-supervised method that treats embodied reasoning as a latent variable and distils a refined reasoning dataset without human annotation or external rewards.
 <!-- tags: paper -->
 
 ## World Models

--- a/website/docs/categories/robotics-foundation-models.mdx
+++ b/website/docs/categories/robotics-foundation-models.mdx
@@ -32,3 +32,4 @@ When choosing between options, weigh **embodiment coverage** vs. your target rob
 - [Gato](https://arxiv.org/abs/2205.06175) — Generalist policy architecture spanning embodied control and non-robotic tasks with tokenized actions.
 - [RoboFlamingo](https://arxiv.org/abs/2311.01378) — Open vision-language-action model for low-cost adaptation to robot manipulation tasks.
 - [MEM — Multi-Scale Embodied Memory](https://arxiv.org/abs/2603.03596) — Memory architecture for vision-language-action models pairing a video encoder for short-horizon recall with language-based long-horizon memory.
+- [R&B-EnCoRe](https://arxiv.org/abs/2602.08167) — Self-supervised method that treats embodied reasoning as a latent variable and distils a refined reasoning dataset without human annotation or external rewards.


### PR DESCRIPTION
## The resource

**[Self-Supervised Bootstrapping of Action-Predictive Embodied Reasoning](https://arxiv.org/abs/2602.08167)** — Milan Ganai, Katie Luo, Jonas Frey, Clark Barrett, Marco Pavone (Stanford, with collaborators at UC Berkeley and NVIDIA). arXiv, February 2026.

The method is named **R&B-EnCoRe** in the abstract; the arXiv title is the descriptive one above.

It targets a circularity in reasoning-augmented VLA training. Current methods specify reasoning primitives — objects in the scene, high-level plans, affordances — through rigid templates, which force the policy to process information irrelevant to the action it needs to predict. Verifying reasoning quality requires a working policy, and building a robust policy requires quality reasoning. R&B-EnCoRe breaks that loop by treating reasoning as a latent variable, generating and distilling a refined reasoning dataset through self-supervised refinement, with no human annotation and no external reward.

Reported results: 28% gain in manipulation success, 101% improvement in navigation score, 21% reduction in collision rate.

## Why it belongs on the list

- **Breadth of validation.** Evaluated across manipulation (Franka Panda in simulation, WidowX on hardware), legged, wheeled, bicycle and quadruped navigation, and autonomous driving — on several different VLA architectures. Cross-embodiment evidence of this spread is uncommon and is the kind of result the list should carry.
- **Addresses a live bottleneck.** Reasoning-augmented VLAs are an active direction, and template rigidity is the practical constraint on them. This is a method for removing it, not commentary on it.
- **Credible provenance.** Stanford, with Pavone and Barrett on the author list.

## Placement

**Robotics Foundation Models**, appended after MEM. It is a training method for VLA policies, sitting naturally with SayCan, Code as Policies, PaLM-E and VIMA. No other section fits it better and no new section is warranted.

Category count: 16 → 17, inside the 15–25 band.

## Verification

```
Robotics Foundation Models          17  OK
TOTAL                              227
Status line OK — 227 entries, last updated 2026-08-20.
PASS — all categories within [15, 25].
```

## Files

- `README.md` — entry plus `<!-- tags: paper -->`, status line 226 → 227
- `website/docs/categories/robotics-foundation-models.mdx` — kept in sync

## Note on ordering

Based on `docs/add-mem-embodied-memory` (#20), which is based on `chore/entry-count-baseline` (#19). Merge order: #19, #20, then this. Each base retargets automatically as the one below it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
