### PR TITLE
docs: add SimToolReal to Sim-to-Real

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Built for researchers and practitioners across the stack — from foundations to
 </p>
 
 <p align="center">
-  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>227 entries</strong> across 14 canonical categories</sub>
+  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>228 entries</strong> across 14 canonical categories</sub>
 </p>
 
 <div align="center">
@@ -338,6 +338,7 @@ Techniques and case studies for transferring policies trained in simulation to r
 - [Learning Robust Perceptive Locomotion (Miki et al.)](https://leggedrobotics.github.io/rl-perceptiveloco/) — Science Robotics result combining proprioceptive and exteroceptive teachers for robust real-world transfer.
 - [Privileged Learning for Rapid Motor Adaptation](https://arxiv.org/abs/2109.11978) — Distillation strategy leveraging privileged simulation signals for robust real-world control.
 - [SimGAN](https://arxiv.org/abs/1612.07828) — Sim-to-real visual adaptation method for narrowing sensor-domain gaps.
+- [SimToolReal](https://simtoolreal.github.io/) — Object-centric RL policy trained on procedurally generated tool primitives, transferring to unseen real tools without task-specific training.
 
 ## Safety & Robustness
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Built for researchers and practitioners across the stack — from foundations to
 </p>
 
 <p align="center">
-  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>226 entries</strong> across 14 canonical categories</sub>
+  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>227 entries</strong> across 14 canonical categories</sub>
 </p>
 
 <div align="center">
@@ -239,6 +239,8 @@ Generalist policies and vision-language-action (VLA) models for robotic control.
 - [RoboFlamingo](https://arxiv.org/abs/2311.01378) — Open vision-language-action model for low-cost adaptation to robot manipulation tasks.
 <!-- tags: paper, open-source -->
 - [MEM — Multi-Scale Embodied Memory](https://arxiv.org/abs/2603.03596) — Memory architecture for vision-language-action models pairing a video encoder for short-horizon recall with language-based long-horizon memory.
+<!-- tags: paper -->
+- [R&B-EnCoRe](https://arxiv.org/abs/2602.08167) — Self-supervised method that treats embodied reasoning as a latent variable and distils a refined reasoning dataset without human annotation or external rewards.
 <!-- tags: paper -->
 
 ## World Models

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Built for researchers and practitioners across the stack — from foundations to
 </p>
 
 <p align="center">
-  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>225 entries</strong> across 14 canonical categories</sub>
+  <sub><strong>Last updated:</strong> 2026-08-20 &middot; <strong>226 entries</strong> across 14 canonical categories</sub>
 </p>
 
 <div align="center">
@@ -238,6 +238,8 @@ Generalist policies and vision-language-action (VLA) models for robotic control.
 <!-- tags: paper -->
 - [RoboFlamingo](https://arxiv.org/abs/2311.01378) — Open vision-language-action model for low-cost adaptation to robot manipulation tasks.
 <!-- tags: paper, open-source -->
+- [MEM — Multi-Scale Embodied Memory](https://arxiv.org/abs/2603.03596) — Memory architecture for vision-language-action models pairing a video encoder for short-horizon recall with language-based long-horizon memory.
+<!-- tags: paper -->
 
 ## World Models
 

--- a/website/docs/categories/robotics-foundation-models.mdx
+++ b/website/docs/categories/robotics-foundation-models.mdx
@@ -31,3 +31,4 @@ When choosing between options, weigh **embodiment coverage** vs. your target rob
 - [VIMA](https://arxiv.org/abs/2210.03094) — Promptable transformer for multimodal robot manipulation via in-context generalization.
 - [Gato](https://arxiv.org/abs/2205.06175) — Generalist policy architecture spanning embodied control and non-robotic tasks with tokenized actions.
 - [RoboFlamingo](https://arxiv.org/abs/2311.01378) — Open vision-language-action model for low-cost adaptation to robot manipulation tasks.
+- [MEM — Multi-Scale Embodied Memory](https://arxiv.org/abs/2603.03596) — Memory architecture for vision-language-action models pairing a video encoder for short-horizon recall with language-based long-horizon memory.

--- a/website/docs/categories/robotics-foundation-models.mdx
+++ b/website/docs/categories/robotics-foundation-models.mdx
@@ -32,3 +32,4 @@ When choosing between options, weigh **embodiment coverage** vs. your target rob
 - [Gato](https://arxiv.org/abs/2205.06175) — Generalist policy architecture spanning embodied control and non-robotic tasks with tokenized actions.
 - [RoboFlamingo](https://arxiv.org/abs/2311.01378) — Open vision-language-action model for low-cost adaptation to robot manipulation tasks.
 - [MEM — Multi-Scale Embodied Memory](https://arxiv.org/abs/2603.03596) — Memory architecture for vision-language-action models pairing a video encoder for short-horizon recall with language-based long-horizon memory.
+- [R&B-EnCoRe](https://arxiv.org/abs/2602.08167) — Self-supervised method that treats embodied reasoning as a latent variable and distils a refined reasoning dataset without human annotation or external rewards.

--- a/website/docs/categories/sim-to-real.mdx
+++ b/website/docs/categories/sim-to-real.mdx
@@ -31,3 +31,4 @@ When choosing between techniques, match the **gap source** to the **method**: dy
 - [Learning Robust Perceptive Locomotion (Miki et al.)](https://leggedrobotics.github.io/rl-perceptiveloco/) — Science Robotics result combining proprioceptive and exteroceptive teachers for robust real-world transfer.
 - [Privileged Learning for Rapid Motor Adaptation](https://arxiv.org/abs/2109.11978) — Distillation strategy leveraging privileged simulation signals for robust real-world control.
 - [SimGAN](https://arxiv.org/abs/1612.07828) — Sim-to-real visual adaptation method for narrowing sensor-domain gaps.
+- [SimToolReal](https://simtoolreal.github.io/) — Object-centric RL policy trained on procedurally generated tool primitives, transferring to unseen real tools without task-specific training.


### PR DESCRIPTION
## The resource

**[SimToolReal: An Object-Centric Policy for Zero-Shot Dexterous Tool Manipulation](https://simtoolreal.github.io/)** — Kushal Kedia and Tyler Ga Wei Lum (equal contribution), advised by Jeannette Bohg and C. Karen Liu (Stanford). RSS 2026. [arXiv](https://arxiv.org/abs/2602.16863) · [code](https://github.com/tylerlum/simtoolreal).

Tool use is a hard corner of dexterity: it needs grasping thin objects, in-hand reorientation, and forceful contact, and teleoperation data for those behaviours is expensive to collect. SimToolReal takes the sim-to-real route instead. It procedurally generates a large variety of tool-like object primitives in simulation and trains a single RL policy against one universal goal — move each object to a random goal pose. At test time the policy handles tools it has never seen, with no object-specific or task-specific training.

Reported results: 37% over prior retargeting and fixed-grasp methods, matching specialist RL policies trained per object and per task, across 120 real-world rollouts spanning 24 tasks, 12 object instances, and 6 tool categories.

## Why it belongs on the list

- **Zero-shot generalisation with real-robot evidence.** 120 real rollouts across 6 tool categories is substantive hardware validation, not a simulation-only claim.
- **The procedural-primitives idea is transferable.** Training on generated object primitives against a universal pose goal, rather than on curated target objects, is a recipe other sim-to-real work can borrow.
- **Fully open and canonical.** Peer-reviewed at RSS 2026, with a project page, arXiv preprint, and released code.

## Placement

**Sim-to-Real**, appended at the bottom.

This one could plausibly sit in Manipulation, so to be explicit about the call: the contribution is the transfer recipe rather than a manipulation architecture, and Sim-to-Real already carries exactly this class of result — `DextrAH-G` ("sim-to-real dexterous arm-hand grasping pipeline using GPU-parallel RL") and `DeXtreme` are its closest neighbours on the list. Placing it beside them is the more discoverable choice. 

Category count: 15 → 16, inside the 15–25 band.

## Verification

```
Sim-to-Real                         16  OK
TOTAL                              228
Status line OK — 228 entries, last updated 2026-08-20.
PASS — all categories within [15, 25].
```

## Files

- `README.md` — entry, status line 227 → 228
- `website/docs/categories/sim-to-real.mdx` — kept in sync


## Note on the link

Pointed at the project page rather than arXiv, since it is the durable hub linking paper, code, and video. Sim-to-Real mixes both conventions (`DextrAH-G` and `DeXtreme` use project pages; most others use arXiv), so this matches local precedent.

## Note on ordering

Last in the stack: `chore/entry-count-baseline` (#19) → `docs/add-mem-embodied-memory` (#20) → `docs/add-rb-encore` (#21) → this. Merge in that order; each base retargets automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
